### PR TITLE
Fix exclude paths in .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -18,4 +18,4 @@ ratings:
 exclude_paths:
 - test/
 - tools/
-- src/**/*spec.js
+- "src/**/**spec.js"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -16,6 +16,6 @@ ratings:
   - "src/**.scss"
   - "src/**.js"
 exclude_paths:
-- test/
-- tools/
+- "test/"
+- "tools/"
 - "src/**/**spec.js"


### PR DESCRIPTION
Abby from Code Climate support here -- I gave more info in my email.

- fixes syntax error for `exclude_paths:` node. 